### PR TITLE
ci: fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     container_name: minio-setup
     depends_on:
       - minio
+    profiles: ['minio-s3-only', 'db-and-minio-s3', 'local-run']
     environment:
       MINIO_ROOT_USER: admin
       MINIO_ROOT_PASSWORD: rootPassword


### PR DESCRIPTION
fix error: service "minio-setup" depends on undefined service "minio": invalid compose project